### PR TITLE
Remove teams

### DIFF
--- a/graphical/messaging.nix
+++ b/graphical/messaging.nix
@@ -1,7 +1,6 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    teams
     zoom-us
     # This had a wired conflict with a LICENSE file
     jitsi-meet
@@ -12,8 +11,4 @@
     slack
     element-desktop
   ];
-
-  xdg.mimeApps.defaultApplications = {
-    "x-scheme-handler/msteams" = [ "teams.desktop" ];
-  };
 }


### PR DESCRIPTION
I don't use it and it seems to not download from the upstream caches.
