### PR TITLE
home-manager-wrapper: Add fallback home-manager

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -12,23 +12,32 @@ in
    {
      # Path to user defined home-manager specific configuration
      home-config-path,
-
      # Name of attribute in the attribute set in home-config-path to use as the
      # root attribute set for home-manager configuration
      # When empty string - uses attribute set in home-config-path as root
      home-attribute ? "",
-
      # Path to nixpkgs used by home-manager modules
      nixpkgs ? nixpkgs-path,
-
      # Package set for building the home-manager cli and this wrapper
      pkgs ? import nixpkgs { },
-
      home-manager ? home-manager-path,
      home-manager-tool ? "$HOME/.nix-profile/bin/home-manager",
+     fallback-tool ?
+       (pkgs.callPackage
+         (home-manager + "/home-manager")
+         { path = null; }
+       ) + "/bin/home-manager",
    }:
    pkgs.writeShellScriptBin "home-manager" ''
-     exec ${home-manager-tool} \
+     home_tool="${fallback-tool}"
+
+     primary_home_tool="${home-manager-tool}"
+
+     if [[ -x $primary_home_tool ]] ; then
+       home_tool="$primary_home_tool"
+     fi
+
+     exec $home_tool \
        -A "${home-attribute}" \
        -I nixpkgs=${nixpkgs} \
        -I home-manager=${home-manager} \


### PR DESCRIPTION
If the path at `home-manager-tool` is not executable run fallback-tool,
which defaults to home-manager from version of home-manager being built.
